### PR TITLE
Don’t link with libstdc++ on non-GNU platforms

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,13 +2,18 @@
 
 extern crate cmake;
 
+use std::env;
+
 fn main() {
     let dst = cmake::Config::new("src").build();
 
     println!("cargo:rustc-link-search=native={}/lib\n\
               cargo:rustc-link-lib=static=brotli\n\
               cargo:rustc-link-lib=static=woff2\n\
-              cargo:rustc-link-lib=static=ots\n\
-              cargo:rustc-link-lib=stdc++",
+              cargo:rustc-link-lib=static=ots",
         dst.display());
+    let target = env::var("TARGET").unwrap();
+    if !target.contains("msvc") {
+        println!("cargo:rustc-link-lib=stdc++");
+    }
 }


### PR DESCRIPTION
Attempt to fix MSVC build in https://github.com/servo/servo/pull/12938.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/fontsan/16)
<!-- Reviewable:end -->
