### PR TITLE
Allow setting external compiler flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,7 +112,7 @@ include_directories(
   ots/third_party/woff2/src
 )
 
-set(CMAKE_CXX_FLAGS "-O3 -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fPIC")
 
 add_library(ots STATIC ${OTS_SOURCES})
 add_library(brotli STATIC ${BROTLI_SOURCES})


### PR DESCRIPTION
Currently `fontsan` ignores custom CXXFLAGS during the build, which can cause problems eg. during cross compilation.

(This is a fix for servo/servo#13154)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/fontsan/20)
<!-- Reviewable:end -->
