### PR TITLE
Add format and MSRV check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,38 @@ jobs:
         run: cargo test -vv
         env:
           RUST_BACKTRACE: 1
+  fmt:
+    name: Format check
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Cargo fmt
+        run: cargo fmt --check
+  msrv:
+    name: Check minimum supported Rust version
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable 6 months ago
+      - name: MSRV build
+        run: cargo build -vv
+      - name: MSRV test
+        run: cargo test -vv
+        env:
+          RUST_BACKTRACE: 1
 
   build_result:
     name: Result
     runs-on: ubuntu-latest
     needs:
       - "build_and_test"
+      - "fmt"
+      - "msrv"
     steps:
       - name: Mark the job as successful
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/examples/check-font.rs
+++ b/examples/check-font.rs
@@ -5,7 +5,7 @@
 
 extern crate fontsan;
 
-use std::io::{Read, self};
+use std::io::{self, Read};
 use std::process;
 
 fn main() {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,13 +3,13 @@
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.
 
-use std::io::{self, Write, Seek, SeekFrom};
+use std::io::{self, Seek, SeekFrom, Write};
 use std::slice;
 
-use libc::{c_int, size_t, off_t};
+use libc::{c_int, off_t, size_t};
 
-pub trait Wr: Write + Seek { }
-impl<T> Wr for T where T: Write + Seek { }
+pub trait Wr: Write + Seek {}
+impl<T> Wr for T where T: Write + Seek {}
 
 pub struct RustOTSStream<'a> {
     pub wr: &'a mut (dyn Wr + 'a),
@@ -21,8 +21,12 @@ extern "C" {
     pub fn RustOTS_Process(stream: *mut RustOTSStream, data: *const u8, len: size_t) -> c_int;
 }
 
-#[no_mangle] pub unsafe extern "C"
-fn RustOTSStream_WriteRaw(stream: *mut RustOTSStream, data: *const u8, len: size_t) -> c_int {
+#[no_mangle]
+pub unsafe extern "C" fn RustOTSStream_WriteRaw(
+    stream: *mut RustOTSStream,
+    data: *const u8,
+    len: size_t,
+) -> c_int {
     let buf = slice::from_raw_parts(data, len as usize);
     // Return success/failure only!
     match (*stream).wr.write_all(buf) {
@@ -34,16 +38,16 @@ fn RustOTSStream_WriteRaw(stream: *mut RustOTSStream, data: *const u8, len: size
     }
 }
 
-#[no_mangle] pub unsafe extern "C"
-fn RustOTSStream_Seek(stream: *mut RustOTSStream, position: off_t) -> c_int {
+#[no_mangle]
+pub unsafe extern "C" fn RustOTSStream_Seek(stream: *mut RustOTSStream, position: off_t) -> c_int {
     match (*stream).wr.seek(SeekFrom::Start(position as u64)) {
         Ok(_) => 1,
         _ => 0,
     }
 }
 
-#[no_mangle] pub unsafe extern "C"
-fn RustOTSStream_Tell(stream: *mut RustOTSStream) -> off_t {
+#[no_mangle]
+pub unsafe extern "C" fn RustOTSStream_Tell(stream: *mut RustOTSStream) -> off_t {
     match (*stream).wr.seek(SeekFrom::Current(0)) {
         Err(e) => {
             // Should be impossible.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,12 @@
 extern crate libc;
 extern crate miniz_sys;
 
-use std::{io, convert, fmt};
 use libc::size_t;
+use std::{convert, fmt, io};
 
 #[cfg(not(test))]
-#[link(name="ots_glue", kind="static")]
-extern "C" { }
+#[link(name = "ots_glue", kind = "static")]
+extern "C" {}
 
 /// Errors that can occur when sanitising a font.
 #[derive(Debug)]
@@ -42,15 +42,15 @@ impl convert::From<io::Error> for Error {
 /// Sanitise a font file, writing the result to `output`.
 #[inline]
 pub fn process_and_write<W>(output: &mut W, font_data: &[u8]) -> Result<(), Error>
-    where W: io::Write + io::Seek,
+where
+    W: io::Write + io::Seek,
 {
     let mut stream = ffi::RustOTSStream {
         wr: output,
         error: None,
     };
     unsafe {
-        if 0 == ffi::RustOTS_Process(&mut stream, font_data.as_ptr(),
-                                     font_data.len() as size_t) {
+        if 0 == ffi::RustOTS_Process(&mut stream, font_data.as_ptr(), font_data.len() as size_t) {
             return Err(Error::InvalidFont);
         }
     }

--- a/tests/smoke-test.rs
+++ b/tests/smoke-test.rs
@@ -5,8 +5,7 @@
 
 extern crate fontsan;
 
-static FIRA_SANS: &'static [u8]
-    = include_bytes!("data/FiraSans-Regular.ttf");
+static FIRA_SANS: &'static [u8] = include_bytes!("data/FiraSans-Regular.ttf");
 
 static NOT_A_FONT: &'static [u8] = br#"
       ___           ___           ___                         ___


### PR DESCRIPTION
 - Add a check that runs `cargo fmt --check`
 - Add a check that fontsan builds with an older Rust version. If servo has an official MSRV policy, then I'd be happy to adapt the number - for now I just arbitrarily chose "stable minus 6 months" for CI.