### PR TITLE
Remove unnecessary ots submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ots"]
-	path = src/ots
-	url = https://github.com/khaledhosny/ots


### PR DESCRIPTION
`ots` is now vendored (see #28) and doesn't need to be submoduled anymore.