### PR TITLE
Link against `libc++` on OpenHarmony OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.1
+
+- Use correct c++ stdlib implementation on OpenHarmony OS.
+
 # 0.5.0
 
 - Fix a build issue on windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontsan"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The Servo Project Developers"]
 description = "Sanitiser for untrusted font files"
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,8 @@ fn main() {
     println!("cargo:rustc-link-lib=static=woff2");
     println!("cargo:rustc-link-lib=static=brotli");
     let target = env::var("TARGET").unwrap();
-    if target.contains("apple") {
+
+    if target.contains("apple") || target.contains("ohos") {
         println!("cargo:rustc-link-lib=c++");
     } else if !target.contains("msvc") {
         println!("cargo:rustc-link-lib=stdc++");


### PR DESCRIPTION
OpenHarmony OS is built with clang and should link against `libc++` and not `libstdc++`.

A better medium term solution would probably be to ditch `cmake-rs` and instead use `cc-rs` which would automatically
emit the correct `rustc-link-lib` line based on the compiler and certain environment variables.