### PR TITLE
fix(woff2): add missing stdint.h include

### DIFF
--- a/src/deps/woff2/include/woff2/output.h
+++ b/src/deps/woff2/include/woff2/output.h
@@ -9,6 +9,8 @@
 #ifndef WOFF2_WOFF2_OUT_H_
 #define WOFF2_WOFF2_OUT_H_
 
+#include <stdint.h>
+
 #include <algorithm>
 #include <cstring>
 #include <memory>


### PR DESCRIPTION
Fixes #36
I applied [this patch](https://github.com/google/woff2/pull/176.patch) for now since the corresponding woff2 PR is still not merged.