### PR TITLE
Remove miniz dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
           - "ubuntu-latest"
           - "macos-latest"
           - "windows-latest"
+        features:
+          - ""
+          - "libz-rs"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -18,9 +21,9 @@ jobs:
         with:
           toolchain: stable
       - name: Build
-        run: cargo build -vv
+        run: cargo build --features "${{ matrix.features }}" -vv
       - name: Test
-        run: cargo test -vv
+        run: cargo test --features "${{ matrix.features }}" -vv
         env:
           RUST_BACKTRACE: 1
   fmt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# unreleased
+
+- Remove miniz dependency and replace with libz bindings (or optionally libz-rs)
+- Update OTS to v0.9.2 (see [upstream ots 0.9.2 release notes])
+
+[upstream ots 0.9.2 release notes]: https://github.com/khaledhosny/ots/releases/tag/v9.2.0
+
 # 0.5.2
 
 - Remove cmake dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# unreleased
+# Unreleased
 
 - Remove miniz dependency and replace with libz bindings (or optionally libz-rs)
 - Update OTS to v0.9.2 (see [upstream ots 0.9.2 release notes])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontsan"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["The Servo Project Developers"]
 description = "Sanitiser for untrusted font files"
 build = "build.rs"
@@ -8,7 +8,17 @@ license = "BSD-3-Clause"
 
 [dependencies]
 libc = "0.2"
-miniz-sys = "0.1.7"
+libz-rs-sys = {  version = "0.5.1", features = ["export-symbols"], optional = true }
+libz-sys = { version = "1.1", default-features = false, features = ["libc" ], optional = true}
+
+[features]
+# zlib is often present as a shared library on the system, meaning smaller binary size
+# if we use bindings to it.
+default = ["libz-sys"]
+# Use libz-rs (a rust implementation of libz) instead of bindings to libz-sys.
+# libz-rs is a bit faster than even libz-ng.
+libz-rs = ["dep:libz-rs-sys"]
+libz-sys = ["dep:libz-sys"]
 
 [build-dependencies]
 cc = { version = "1.0.89", features = ["parallel"] }

--- a/src/fake-zlib/zlib.h
+++ b/src/fake-zlib/zlib.h
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.
 
-// Declares the zlib API subset used by ots, and links it to miniz.
+// Declares the zlib API subset used by ots
 
 #ifndef ZLIB_H
 #define ZLIB_H
@@ -17,13 +17,10 @@ extern "C" {
 typedef unsigned char Bytef;
 typedef unsigned long uLongf;
 
-int mz_uncompress(unsigned char *pDest,
+int uncompress(unsigned char *pDest,
                   unsigned long *pDest_len,
                   const unsigned char *pSource,
                   unsigned long source_len);
-
-#define uncompress mz_uncompress
-#define inflateEnd mz_inflateEnd
 
 #define Z_OK 0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,10 @@
 // that can be found in the LICENSE file.
 
 extern crate libc;
-extern crate miniz_sys;
+#[cfg(feature = "libz-rs")]
+extern crate libz_rs_sys;
+#[cfg(feature = "libz-sys")]
+extern crate libz_sys;
 
 use libc::size_t;
 use std::{convert, fmt, io};


### PR DESCRIPTION
Use the standard libz-sys instead of miniz and optionally libz-rs.
miniz is rarely used, and most dependency trees anyway depend on
libz in some way, and most systems also ship a libz shared library.

This allows us to remove the miniz dependency from Servo, and optionally
allows us to use libz-rs, which can offer better performance in some cases.