### PR TITLE
MSVC: Avoid unknown option -std:c++11 build warning 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Remove miniz dependency and replace with libz bindings (or optionally libz-rs)
 - Update OTS to v0.9.2 (see [upstream ots 0.9.2 release notes])
+- Update LZ4 to v1.10.0 (#41)
 
 [upstream ots 0.9.2 release notes]: https://github.com/khaledhosny/ots/releases/tag/v9.2.0
 


### PR DESCRIPTION
MSVC doesn't support C++11 and defaults to C++14, so we just don't set a flag for MSVC.

The upstream build systems for Woff2 [uses C++11](https://github.com/google/woff2/blob/0f4d304faa1c62994536dc73510305c7357da8d4/CMakeLists.txt#L64) as well as [ots](https://github.com/khaledhosny/ots/blob/ee75ff5dcef67fcd3ea7255044c889349e210750/meson.build#L3). 

Note: This PR is based on #39, so only need to review the last commit.