### PR TITLE
Explicitly set 2015 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Servo Project Developers"]
 description = "Sanitiser for untrusted font files"
 build = "build.rs"
 license = "BSD-3-Clause"
+edition = "2015"
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
This silences the following warning:

```
warning: no edition set: defaulting to the 2015 edition while the latest is 2024
```

We can still update the edition later separately.