### PR TITLE
CI: Add workflows for automated publish

### DIFF
--- a/.github/workflows/prepare-new-release.yml
+++ b/.github/workflows/prepare-new-release.yml
@@ -1,5 +1,7 @@
 name: Prepare new release
 
+# Needs permissions as specified in:
+# https://release-plz.ieni.dev/docs/github/quickstart
 permissions:
   pull-requests: write
   contents: write

--- a/.github/workflows/prepare-new-release.yml
+++ b/.github/workflows/prepare-new-release.yml
@@ -1,0 +1,32 @@
+name: Prepare new release
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  new-release:
+    name: Prepare new release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,12 +1,14 @@
 name: Publish release
 
+# Needs permissions as specified in:
+# https://release-plz.ieni.dev/docs/github/quickstart
 permissions:
   contents: write
 
 on:
   push:
     tags:
-      - "*"
+      - "v*"
 
 jobs:
   publish:
@@ -26,5 +28,9 @@ jobs:
         with:
           command: release
         env:
+          # Needs permissions as specified in:
+          # https://release-plz.ieni.dev/docs/github/quickstart#1-change-github-actions-permissions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Needs permissions as specified in:
+          # https://release-plz.ieni.dev/docs/github/quickstart#2-set-the-cargo_registry_token-secret
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,30 @@
+name: Publish release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,8 +5,8 @@ permissions:
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "*"
 
 jobs:
   publish:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+git_tag_enable = false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,2 +1,4 @@
 [workspace]
+# we trigger publish by creating tag
+# so we can assume it's already created
 git_tag_enable = false


### PR DESCRIPTION
This PR adds `Prepare new release` workflow which needs to be manually dispatched (available only to contributors) to create new release PR, that one can edit/change before merging.
Then there is also `Publish release` workflows, which is triggered by creating a tag (we should restrict those using ruleset to release managers) and publishes release to crates.io and creates GitHub release from tag.

Based on https://release-plz.ieni.dev/docs/github/quickstart.

Needs admin to follow instructions on https://release-plz.ieni.dev/docs/github/quickstart#1-change-github-actions-permissions for secrets and workflow permissions.